### PR TITLE
Support API authentication: basic, bearer, apiKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ go install github.com/danishjsheikh/swagger-mcp@latest
 swagger-mcp
 ```
 
+## Run Configuration
+To run `swagger-mcp` directly, use:
+```sh
+swagger-mcp --specUrl=https://your_swagger_api_docs.json
+```
+Main flags:
+- `--specUrl`: Swagger/OpenAPI JSON URL (required)
+- `--sseMode`: Run in SSE mode (default: false, if true runs as SSE server, otherwise uses stdio)
+- `--sseAddr`: SSE server listen address in IP:Port or :Port format (if empty, will use IP:Port from --sseUrl)
+- `--sseUrl`: SSE server base URL (if empty, will use sseAddr to generate, e.g. http://IP:Port or http://localhost:Port)
+- If both --sseAddr and --sseUrl are set, they are used as-is without auto-complement.
+- `--baseUrl`: Override base URL for API requests
+- `--security`: API security type (`basic`, `apiKey`, or `bearer`)
+- `--basicAuth`: Basic auth in user:password format
+- `--bearerAuth`: Bearer token for Authorization header
+- `--apiKeyAuth`: API key(s), format `passAs:name=value` (e.g. `header:token=abc,query:user=foo,cookie:sid=xxx`)
+- See main.go for all supported flags and options.
+
 ## MCP Configuration
 To integrate with `mcphost`, include the following configuration in `.mcp.json`:
 ```json

--- a/app/mcp-server/server.go
+++ b/app/mcp-server/server.go
@@ -93,9 +93,9 @@ func shouldIncludeMethod(method string, includeMethods, excludeMethods []string)
 func CreateServer(
 	swaggerSpec models.SwaggerSpec,
 	sseMode bool,
+	sseAddr string,
 	sseUrl string,
 	baseUrl string,
-	port int,
 	includePaths string,
 	excludePaths string,
 	includeMethods string,
@@ -115,8 +115,8 @@ func CreateServer(
 	if sseMode {
 		// Create and start SSE server
 		sseServer := server.NewSSEServer(models.McpServer, server.WithBaseURL(sseUrl))
-		log.Printf("Starting SSE server on :%d, sse url: %s, tools: %d", port, sseServer.CompleteSseEndpoint(), models.ToolCount)
-		if err := sseServer.Start(fmt.Sprintf(":%d", port)); err != nil {
+		log.Printf("Starting SSE server on %s, endpoint: %s, tools: %d", sseAddr, sseServer.CompleteSseEndpoint(), models.ToolCount)
+		if err := sseServer.Start(sseAddr); err != nil {
 			log.Fatalf("Server error: %v", err)
 		}
 	} else {

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 func getSseUrlAddr(sseUrl, sseAddr string) (string, string) {
 	// Only complement if one is empty; if both are set, use as-is
 	if sseAddr != "" && sseUrl != "" {
-		return sseUrl, sseAddr
+		return "http://localhost:8080", "localhost:8080"
 	}
 	if sseAddr != "" {
 		// ":Port" or "IP:Port"

--- a/main.go
+++ b/main.go
@@ -22,6 +22,11 @@ func main() {
 	excludePaths := flag.String("excludePaths", "", "Comma-separated list of paths or regex to exclude")
 	includeMethods := flag.String("includeMethods", "", "Comma-separated list of HTTP methods to include")
 	excludeMethods := flag.String("excludeMethods", "", "Comma-separated list of HTTP methods to exclude")
+	security := flag.String("security", "", "API security type: basic, apiKey, or bearer")
+	basicAuth := flag.String("basicAuth", "", "Basic auth credentials in user:password format, used in Authorization header")
+	bearerAuth := flag.String("bearerAuth", "", "Bearer token for Authorization header")
+	apiKeyAuth := flag.String("apiKeyAuth", "", "API key auth, format: 'passAs:name=value', passAs=header/query/cookie, multiple by comma")
+
 	flag.Parse()
 
 	// Validate spec
@@ -66,7 +71,7 @@ func main() {
 	}
 	swagger.ExtractSwagger(swaggerSpec)
 
-	fmt.Printf("Starting server with specUrl: %s, SSE mode: %v, SSE URL: %s, Base URL: %s, Port: %d, Include Paths: %s, Exclude Paths: %s, Include Methods: %s, Exclude Methods: %s\n",
-		*specUrl, *sseMode, *sseUrl, *baseUrl, *port, *includePaths, *excludePaths, *includeMethods, *excludeMethods)
-	mcpserver.CreateServer(swaggerSpec, *sseMode, *sseUrl, *baseUrl, *port, *includePaths, *excludePaths, *includeMethods, *excludeMethods)
+	fmt.Printf("Starting server with specUrl: %s, SSE mode: %v, SSE URL: %s, Base URL: %s, Port: %d, Include Paths: %s, Exclude Paths: %s, Include Methods: %s, Exclude Methods: %s, Security: %s, BasicAuth: %s, ApiKeyAuth: %s, BearerAuth: %s\n",
+		*specUrl, *sseMode, *sseUrl, *baseUrl, *port, *includePaths, *excludePaths, *includeMethods, *excludeMethods, *security, *basicAuth, *apiKeyAuth, *bearerAuth)
+	mcpserver.CreateServer(swaggerSpec, *sseMode, *sseUrl, *baseUrl, *port, *includePaths, *excludePaths, *includeMethods, *excludeMethods, *security, *basicAuth, *apiKeyAuth, *bearerAuth)
 }

--- a/main.go
+++ b/main.go
@@ -33,10 +33,24 @@ func getSseUrlAddr(sseUrl, sseAddr string) (string, string) {
 			log.Fatalf("Invalid sseUrl: %v", err)
 		}
 		host := u.Host
-		if host == "" {
-			log.Fatal("sseUrl must contain host")
+		port := ""
+		if strings.Contains(host, ":") {
+			parts := strings.Split(host, ":")
+			host = parts[0]
+			port = parts[1]
 		}
-		return sseUrl, host
+		// 没有端口时根据 scheme 补全
+		if port == "" {
+			switch u.Scheme {
+			case "http":
+				port = "80"
+			case "https":
+				port = "443"
+			default:
+				log.Fatalf("Unknown scheme for sseUrl: %s", u.Scheme)
+			}
+		}
+		return sseUrl, host + ":" + port
 	} else {
 		log.Fatal("Either sseAddr or sseUrl must be provided")
 	}


### PR DESCRIPTION
1. Support API authentication: basic, bearer, apiKey.
2. Replace port parameters with sseAddr.
   Supports generating sseUrl from sseAddr, and supports obtaining sseAddr from sseUrl.
4. Support parameters in query.