### PR TITLE
Enhance Swagger Specification Handling

### DIFF
--- a/app/models/models.go
+++ b/app/models/models.go
@@ -2,11 +2,38 @@ package models
 
 import "github.com/mark3labs/mcp-go/server"
 
+type Server struct {
+	URL         string `json:"url"`
+	Description string `json:"description,omitempty"`
+}
+
 type SwaggerSpec struct {
-	Host        string                         `json:"host"`
-	BasePath    string                         `json:"basePath"`
+	// Swagger 2.0 fields
+	Host        string                         `json:"host,omitempty"`
+	BasePath    string                         `json:"basePath,omitempty"`
+	Swagger     string                         `json:"swagger,omitempty"`
+	
+	// OpenAPI 3.0 fields
+	OpenAPI     string                         `json:"openapi,omitempty"`
+	Servers     []Server                       `json:"servers,omitempty"`
+	Components  *Components                    `json:"components,omitempty"`
+	
+	// Common fields
 	Paths       map[string]map[string]Endpoint `json:"paths"`
-	Definitions map[string]Definition          `json:"definitions"`
+	Definitions map[string]Definition          `json:"definitions,omitempty"` // Swagger 2.0
+}
+
+type Components struct {
+	Schemas map[string]Definition `json:"schemas,omitempty"` // OpenAPI 3.0
+}
+
+type Definition struct {
+	Type       string              `json:"type"`
+	Properties map[string]Property `json:"properties"`
+}
+
+type Property struct {
+	Type string `json:"type"`
 }
 
 type Endpoint struct {
@@ -14,8 +41,8 @@ type Endpoint struct {
 	Description string              `json:"description"`
 	Parameters  []Parameter         `json:"parameters"`
 	Responses   map[string]Response `json:"responses"`
-	Consumes    []string            `json:"consumes"`
-	Produces    []string            `json:"produces"`
+	Consumes    []string           `json:"consumes"`
+	Produces    []string           `json:"produces"`
 }
 
 type Parameter struct {
@@ -38,15 +65,4 @@ type SchemaRef struct {
 	Type string `json:"type,omitempty"`
 }
 
-type Definition struct {
-	Type       string              `json:"type"`
-	Properties map[string]Property `json:"properties"`
-}
-
-type Property struct {
-	Type string `json:"type"`
-}
-
 var McpServer *server.MCPServer
-
-var BaseUrl string

--- a/app/swagger/extracter.go
+++ b/app/swagger/extracter.go
@@ -14,52 +14,92 @@ func ExtractSchemaName(ref, schemaType string) string {
 	}
 	return schemaType
 }
+
+func getBaseURL(swaggerSpec models.SwaggerSpec) string {
+	// For OpenAPI 3.0
+	if swaggerSpec.OpenAPI != "" && len(swaggerSpec.Servers) > 0 {
+		return strings.TrimSuffix(swaggerSpec.Servers[0].URL, "/")
+	}
+	
+	// For Swagger 2.0
+	baseURL := swaggerSpec.Host
+	if !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
+		baseURL = "https://" + baseURL
+	}
+	if swaggerSpec.BasePath != "" {
+		baseURL = strings.TrimSuffix(baseURL, "/") + "/" + strings.TrimPrefix(swaggerSpec.BasePath, "/")
+	}
+	return baseURL
+}
+
 func ExtractSwagger(swaggerSpec models.SwaggerSpec) {
+	baseURL := getBaseURL(swaggerSpec)
+	
 	for path, methods := range swaggerSpec.Paths {
 		for method, details := range methods {
-			fmt.Printf("Endpoint: %s\n", swaggerSpec.Host+swaggerSpec.BasePath+path)
-			fmt.Printf("Method: %s\n", method)
+			fullURL := strings.TrimSuffix(baseURL, "/") + "/" + strings.TrimPrefix(path, "/")
+			fmt.Printf("\nEndpoint: %s\n", fullURL)
+			fmt.Printf("Method: %s\n", strings.ToUpper(method))
 			fmt.Printf("Summary: %s\n", details.Summary)
 			fmt.Printf("Description: %s\n", details.Description)
-			fmt.Println("Headers:")
+			
+			fmt.Println("\nHeaders:")
 			for _, param := range details.Parameters {
 				if param.In == "header" {
 					fmt.Printf("  - %s (Required: %t)\n", param.Name, param.Required)
 				}
 			}
-			fmt.Println("Path Paramters:")
+			
+			fmt.Println("\nPath Parameters:")
+			for _, param := range details.Parameters {
+				if param.In == "path" {
+					fmt.Printf("  - %s (Required: %t, Type: %s)\n", param.Name, param.Required, param.Type)
+					if param.Description != "" {
+						fmt.Printf("    Description: %s\n", param.Description)
+					}
+				}
+			}
 
-			fmt.Println("Request Body:")
+			fmt.Println("\nRequest Body:")
 			for _, param := range details.Parameters {
 				if param.In == "body" {
 					schemaName := ExtractSchemaName(param.Schema.Ref, param.Type)
-					fmt.Printf("  - %s (Schema: %s)\n", param.Name, schemaName)
+					fmt.Printf("  Schema: %s\n", schemaName)
 					if definition, found := swaggerSpec.Definitions[schemaName]; found {
 						for propName, prop := range definition.Properties {
 							fmt.Printf("    - %s: %s\n", propName, prop.Type)
 						}
 					} else if schemaName != "" {
-						fmt.Printf("    - Type: %s\n", schemaName)
+						fmt.Printf("    Type: %s\n", schemaName)
 					}
 				}
 			}
-			fmt.Println("Response Body:")
+			
+			fmt.Println("\nResponse Body:")
 			for status, resp := range details.Responses {
+				fmt.Printf("  Status %s:\n", status)
 				if resp.Schema != nil {
 					schemaName := ExtractSchemaName(resp.Schema.Ref, resp.Schema.Type)
-					fmt.Printf("  - Status: %s, Schema: %s\n", status, schemaName)
 					if definition, found := swaggerSpec.Definitions[schemaName]; found {
+						fmt.Printf("    Schema: %s\n", schemaName)
 						for propName, prop := range definition.Properties {
-							fmt.Printf("    - %s: %s\n", propName, prop.Type)
+							fmt.Printf("      - %s: %s\n", propName, prop.Type)
 						}
-					} else if schemaName != "" {
-						fmt.Printf("    - Type: %s\n", schemaName)
+					} else if resp.Schema.Type != "" {
+						fmt.Printf("    Type: %s\n", resp.Schema.Type)
+					} else {
+						fmt.Printf("    Schema Reference: %s\n", resp.Schema.Ref)
 					}
+				} else if resp.Type != "" {
+					fmt.Printf("    Type: %s\n", resp.Type)
 				} else {
-					fmt.Printf("  - Status: %s, No schema defined\n", status)
+					fmt.Printf("    No response schema defined\n")
+				}
+				if resp.Description != "" {
+					fmt.Printf("    Description: %s\n", resp.Description)
 				}
 			}
-			fmt.Println("----------------------------")
+			fmt.Println("\n----------------------------")
 		}
 	}
 }


### PR DESCRIPTION
- Updated `SwaggerSpec` struct to support OpenAPI 3.0 fields, including `Servers` and `Components`.
- Refactored URL generation logic in `LoadSwaggerServer` and `ExtractSwagger` to accommodate both OpenAPI 3.0 and Swagger 2.0 specifications.
- Improved response handling in `ExtractSwagger` for better clarity on response schemas and types.