### PR TITLE
feat: operationId-based tool names and optional parameter handling

### DIFF
--- a/app/mcp-server/server.go
+++ b/app/mcp-server/server.go
@@ -204,7 +204,9 @@ func LoadSwaggerServer(mcpServer *server.MCPServer, swaggerSpec models.SwaggerSp
 			reqBody := make(map[string]string)
 			reqPathParam := []string{}
 			reqQueryParam := []string{}
+			reqQueryParamRequired := map[string]bool{}
 			reqHeader := []string{}
+			reqHeaderRequired := map[string]bool{}
 
 			for _, param := range details.Parameters {
 				if param.In == "header" {
@@ -221,6 +223,7 @@ func LoadSwaggerServer(mcpServer *server.MCPServer, swaggerSpec models.SwaggerSp
 						))
 					}
 					reqHeader = append(reqHeader, param.Name)
+					reqHeaderRequired[param.Name] = param.Required
 				}
 			}
 			for _, param := range details.Parameters {
@@ -238,6 +241,7 @@ func LoadSwaggerServer(mcpServer *server.MCPServer, swaggerSpec models.SwaggerSp
 						))
 					}
 					reqQueryParam = append(reqQueryParam, param.Name)
+					reqQueryParamRequired[param.Name] = param.Required
 				}
 			}
 
@@ -293,7 +297,7 @@ func LoadSwaggerServer(mcpServer *server.MCPServer, swaggerSpec models.SwaggerSp
 			mcpServer.AddTool(
 				mcp.NewTool(toolName, toolOption...),
 				CreateMCPToolHandler(
-					reqPathParam, reqQueryParam, reqURL, reqBody, reqMethod, reqHeader, apiCfg,
+					reqPathParam, reqQueryParam, reqQueryParamRequired, reqURL, reqBody, reqMethod, reqHeader, reqHeaderRequired, apiCfg,
 				),
 			)
 		}
@@ -365,10 +369,12 @@ func setRequestSecurity(req *http.Request, security string, basicAuth string, ap
 func CreateMCPToolHandler(
 	reqPathParam []string,
 	reqQueryParam []string,
+	reqQueryParamRequired map[string]bool,
 	reqURL string,
 	reqBody map[string]string,
 	reqMethod string,
 	reqHeader []string,
+	reqHeaderRequired map[string]bool,
 	apiCfg models.ApiConfig,
 ) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -393,12 +399,14 @@ func CreateMCPToolHandler(
 			}
 			q := u.Query()
 			for _, name := range reqQueryParam {
-				if arguments == nil {
-					return mcp.NewToolResultError(fmt.Sprintf("[Error] missing or invalid Query Parameter: %s", name)), nil
-				}
 				val, ok := arguments[name].(string)
-				if !ok {
-					return mcp.NewToolResultError(fmt.Sprintf("[Error] missing or invalid Query Parameter: %s", name)), nil
+				if !ok || val == "" {
+					// Only return error if this parameter is required
+					if reqQueryParamRequired[name] {
+						return mcp.NewToolResultError(fmt.Sprintf("[Error] missing or invalid Query Parameter: %s", name)), nil
+					}
+					// Skip optional parameters that are not provided
+					continue
 				}
 				q.Set(name, val)
 			}
@@ -472,12 +480,14 @@ func CreateMCPToolHandler(
 		}
 
 		for _, headerName := range reqHeader {
-			if arguments == nil {
-				return mcp.NewToolResultError(fmt.Sprintf("[Error] missing or invalid Header: %s", headerName)), nil
-			}
 			headerValue, ok := arguments[headerName].(string)
-			if !ok {
-				return mcp.NewToolResultError(fmt.Sprintf("[Error] missing or invalid Header: %s", headerName)), nil
+			if !ok || headerValue == "" {
+				// Only return error if this header is required
+				if reqHeaderRequired[headerName] {
+					return mcp.NewToolResultError(fmt.Sprintf("[Error] missing or invalid Header: %s", headerName)), nil
+				}
+				// Skip optional headers that are not provided
+				continue
 			}
 			req.Header.Add(headerName, headerValue)
 		}

--- a/app/mcp-server/server.go
+++ b/app/mcp-server/server.go
@@ -288,7 +288,7 @@ func LoadSwaggerServer(mcpServer *server.MCPServer, swaggerSpec models.SwaggerSp
 			toolOption = append(toolOption, mcp.WithDescription(fmt.Sprintf(`Use this tool only when the request exactly matches %s or %s. If you dont have any of the required parameters then always ask user for it, *Dont fill any paramter on your own or keep it empty*. If there is [Error], only state that error in your reponse and stop the reponse there itself. *Do not ever maintain records in your memory for eg list of users or orders*`,
 				details.Summary, details.Description)))
 
-			toolName := fmt.Sprintf("%s_%s", method, strings.ReplaceAll(strings.ReplaceAll(path, "}", ""), "{", ""))
+			toolName := createFriendlyToolName(method, path, details.OperationID)
 
 			mcpServer.AddTool(
 				mcp.NewTool(toolName, toolOption...),
@@ -525,4 +525,16 @@ func CreateMCPToolHandler(
 		fmt.Printf("Response : %s\n", string(body))
 		return mcp.NewToolResultText(string(body)), nil
 	}
+}
+
+// createFriendlyToolName generates user-friendly tool names based on operationID
+// Falls back to the original method_path format if operationID is not available
+func createFriendlyToolName(method, path string, operationID string) string {
+	// Use operationID if available
+	if operationID != "" {
+		return strings.ReplaceAll(operationID, "_", "-")
+	}
+
+	// Fallback to old format: method_path (guarantees uniqueness)
+	return fmt.Sprintf("%s_%s", method, strings.ReplaceAll(strings.ReplaceAll(path, "}", ""), "{", ""))
 }

--- a/app/models/models.go
+++ b/app/models/models.go
@@ -35,6 +35,7 @@ type Property struct {
 }
 
 type Endpoint struct {
+    OperationID string              `json:"operationId,omitempty"`
 	Summary     string              `json:"summary"`
 	Description string              `json:"description"`
 	Parameters  []Parameter         `json:"parameters"`


### PR DESCRIPTION
This PR adds two improvements to the MCP server:

**Use operationId for tool names** - Generate readable tool names from Swagger operationId
**Fix optional parameter handling** - Optional query parameters and headers no longer cause errors

## Changes

### OperationId-based Tool Names

  **Problem:** Tool names were always generated as `method_path` (e.g., `get_/api/users/{id}`), which are hard to read and use.

  **Solution:** Prefer `operationId` from [Swagger spec when available](https://swagger.io/docs/specification/v3_0/paths-and-operations/), fall back to `method_path` format for guaranteed uniqueness.

  **Example:**
  - With operationId `getUserById` → tool name: `getUserById` or `get-user-by-id`
  - Without operationId → tool name: `get_/users/{id}` (original format)

  **Files changed:**
  - `app/models/models.go`: Added `OperationID` field to `Endpoint` struct
  - `app/mcp-server/server.go`: Added `createFriendlyToolName()` function

### Optional Parameter Handling Fix

  **Problem:** Optional query parameters and headers were incorrectly treated as mandatory, causing API calls to fail with `[Error] missing or
  invalid Query Parameter` even when marked as `required: false`.

  **Solution:** Track which parameters are required and only error on missing required parameters.

  **Behavior:**
  - Required param missing → Error (as expected)
  - Optional param missing → Skipped (no error)
  - Optional param empty → Skipped (no error)
